### PR TITLE
Vfnext quality params

### DIFF
--- a/vfnext/main.nf
+++ b/vfnext/main.nf
@@ -61,6 +61,8 @@ log.info """
          --fastp_threads    : ${params.fastp_threads}
          --bwa_threads      : ${params.bwa_threads}
          --mafft_threads    : ${params.mafft_threads}
+         --mapping_quality  : ${params.mapping_quality}
+         --base_quality     : ${params.base_quality}
          
         
         * Only required for "custom" virus

--- a/vfnext/modules/runIvar.nf
+++ b/vfnext/modules/runIvar.nf
@@ -12,15 +12,15 @@ process runIvar{
     """
     # IVAR STEP 1 ----------------------------------------------------------------
     samtools mpileup -aa -d 50000 --reference ${ref_fa} -a -B ${sorted_bam} | \
-       ivar variants -p ${sample_id} -q 30 -t 0.05
+       ivar variants -p ${sample_id} -q ${params.mapping_quality} -t 0.05
 
     # IVAR STEP 2 ----------------------------------------------------------------
     samtools mpileup -aa -d 50000 --reference ${ref_fa} -a -B ${sorted_bam} | \
-       ivar consensus -p ${sample_id} -q 30 -t 0 -m ${d} -n N
+       ivar consensus -p ${sample_id} -q ${params.mapping_quality} -t 0 -m ${d} -n N
 
     # IVAR STEP 3 ----------------------------------------------------------------
     samtools mpileup -aa -d 50000 --reference ${ref_fa} -a -B -B ${sorted_bam} | \
-       ivar consensus -p ${sample_id}.ivar060 -q 30 -t 0.60 -n N -m ${params.depth}
+       ivar consensus -p ${sample_id}.ivar060 -q ${params.mapping_quality} -t 0.60 -n N -m ${params.depth}
     # EDIT FILE NAMES
     mv ${sample_id}.fa ${sample_id}.depth${d}.fa
     mv ${sample_id}.ivar060.fa ${sample_id}.depth${d}.amb.fa

--- a/vfnext/modules/runPicard.nf
+++ b/vfnext/modules/runPicard.nf
@@ -14,7 +14,9 @@ process runPicard {
   """
   ${java_cmd} CollectWgsMetrics -I ${sorted_bam} \
                                 -R ${ref_fa}\
-                                -O wgs -CAP 99999
+                                -O wgs -CAP 99999 \
+                                -Q ${params.base_quality} \
+                                -MQ ${params.mapping_quality}
 
   ${java_cmd} CollectMultipleMetrics -I ${sorted_bam} \
                                      -R ${ref_fa}\

--- a/vfnext/modules/runSnpEff.nf
+++ b/vfnext/modules/runSnpEff.nf
@@ -17,7 +17,7 @@ process runSnpEff{
   sorted_bam = "${bam_files[0].getSimpleName()}.sorted.bam"
   if (params.virus == "custom")
     """
-    freebayes -p 1 --reference-quality 30 \
+    freebayes -p 1 --reference-quality ${params.mapping_quality},${params.base_quality} \
             -f ${ref_fa} ${sorted_bam} > ${sample_id}.vcf
     snpEff ann -Xmx4g \
             -v ${genome_code} ${sample_id}.vcf > ${sample_id}.ann.vcf

--- a/vfnext/modules/runSnpEff.nf
+++ b/vfnext/modules/runSnpEff.nf
@@ -26,7 +26,7 @@ process runSnpEff{
     """
   else
     """
-    freebayes -p 1 --reference-quality 30 \
+    freebayes -p 1 --reference-quality ${params.mapping_quality},${params.base_quality} \
             -f ${ref_fa} ${sorted_bam} > ${sample_id}.vcf
     snpEff download -v ${genome_code}
     snpEff ann -Xmx4g \

--- a/vfnext/nextflow.config
+++ b/vfnext/nextflow.config
@@ -27,6 +27,10 @@ params {
 
   // set available resources for nextflow
   nextflowSimCalls = null
+
+  // set quality params
+  mapping_quality = 30
+  base_quality = 30
   
   // set nunmber for multithreads
   fastp_threads = 1

--- a/wrapper/__init__.py
+++ b/wrapper/__init__.py
@@ -75,7 +75,9 @@ def parse_params(in_flpath):
         "fastp_threads",
         "bwa_threads",
         "mafft_threads",
-        "nxtclade_jobs"
+        "nxtclade_jobs",
+        "mapping_quality",
+        "base_quality"
     ]
     path_params = ["inDir", "outDir", "referenceGFF", "referenceGenome", "adaptersFile"]
     in_file = open(in_flpath, "r")


### PR DESCRIPTION
A ideia desse PR é adicionar os parâmetros base quality e mapping quality.

Como estamos adicionando novas etapas que não haviam no viralflow 0.6, como o picard e o freebayes, é necessário que todas as ferramentas que trabalhem com qualidade de base e de mapeamento (ivar, freebayes, picard) estejam alinhadas.

Dessa forma, foram adicionados os parametros base_quality e mapping_quality com valor default de 30 (mapeado em phred score = 99.9 acurácia).

Fiz dois testes, um sem passar esses argumentos - logo sendo usados os default - onde:

```
===========================================
 VFNEXT_0.1 (dev : alpha)
 Used parameters:
-------------------------------------------
 --inDir            : /home/filipe/Git/ViralFlow/test_files/sars-cov-2/input
 --outDir           : /home/filipe/Git/ViralFlow/test_files/sars-cov-2/outputs
 --virus            : sars-cov2
 --refGenomeCode   *: null
 --referenceGenome *: null
 --referenceGFF    *: null
 --adaptersFile     : /home/filipe/Git/ViralFlow/test_files/sars-cov-2/input/ART_adapters.fa
 --threads          : null
 --minLen           : 75
 --depth            : 5
 --minDpIntrahost   : 100
 --trimLen          : 0
 --databaseDir      : /home/filipe/Git/ViralFlow/vfnext/databases/
 --runSnpEff        : true
 --writeMappedReads : true
 --nextflowSimCalls : null
 --fastp_threads    : 1
 --bwa_threads      : 1
 --mafft_threads    : 1
 --mapping_quality  : 30
 --base_quality     : 30
```
Conferindo o .command.sh de cada tarefa, temos:

```bash
# IVAR STEP 1 ----------------------------------------------------------------
samtools mpileup -aa -d 50000 --reference NC_045512.2.fa -a -B ART1.sorted.bam | ivar variants -p ART1 -q 30 -t 0.05
# IVAR STEP 2 ----------------------------------------------------------------
samtools mpileup -aa -d 50000 --reference NC_045512.2.fa -a -B ART1.sorted.bam | ivar consensus -p ART1 -q 30 -t 0 -m 5 -n N
# IVAR STEP 3 ----------------------------------------------------------------
samtools mpileup -aa -d 50000 --reference NC_045512.2.fa -a -B -B ART1.sorted.bam | ivar consensus -p ART1.ivar060 -q 30 -t 0.60 -n N -m 5

java -jar /app/picard.jar CollectWgsMetrics -I ART1.sorted.bam -R NC_045512.2.fa -O wgs -CAP 99999 -Q 30 -MQ 30

freebayes -p 1 --reference-quality 30,30 -f NC_045512.2.fa Cneg.sorted.bam > Cneg.vcf
```

E adicionando os valores 40 ao sars-cov2.params:

```
mapping_quality 40
base_quality 40
```

Temos:

```
===========================================
 VFNEXT_0.1 (dev : alpha)
 Used parameters:
-------------------------------------------
 --inDir            : /home/filipe/Git/ViralFlow/test_files/sars-cov-2/input
 --outDir           : /home/filipe/Git/ViralFlow/test_files/sars-cov-2/outputs
 --virus            : sars-cov2
 --refGenomeCode   *: null
 --referenceGenome *: null
 --referenceGFF    *: null
 --adaptersFile     : /home/filipe/Git/ViralFlow/test_files/sars-cov-2/input/ART_adapters.fa
 --threads          : null
 --minLen           : 75
 --depth            : 5
 --minDpIntrahost   : 100
 --trimLen          : 0
 --databaseDir      : /home/filipe/Git/ViralFlow/vfnext/databases/
 --runSnpEff        : true
 --writeMappedReads : true
 --nextflowSimCalls : null
 --fastp_threads    : 1
 --bwa_threads      : 1
 --mafft_threads    : 1
 --mapping_quality  : 40
 --base_quality     : 40
```

Conferindo no .command.sh:

```bash
#!/bin/bash -ue
# IVAR STEP 1 ----------------------------------------------------------------
samtools mpileup -aa -d 50000 --reference NC_045512.2.fa -a -B ART2.sorted.bam | ivar variants -p ART2 -q 40 -t 0.05

# IVAR STEP 2 ----------------------------------------------------------------
samtools mpileup -aa -d 50000 --reference NC_045512.2.fa -a -B ART2.sorted.bam | ivar consensus -p ART2 -q 40 -t 0 -m 5 -n N

# IVAR STEP 3 ----------------------------------------------------------------
samtools mpileup -aa -d 50000 --reference NC_045512.2.fa -a -B -B ART2.sorted.bam | ivar consensus -p ART2.ivar060 -q 40 -t 0.60 -n N -m 5

java -jar /app/picard.jar CollectWgsMetrics -I ART1.sorted.bam -R NC_045512.2.fa -O wgs -CAP 99999 -Q 40 -MQ 40

freebayes -p 1 --reference-quality 40,40 -f NC_045512.2.fa Cneg.sorted.bam > Cneg.vcf
```