### PR TITLE
fix compileOutput.py script to run on viralflow env

### DIFF
--- a/envs/env.yml
+++ b/envs/env.yml
@@ -49,8 +49,8 @@ dependencies:
   - openssl=3.0.5=h166bdaf_2
   - pip=22.3=pyhd8ed1ab_0
   - python=3.9.13=h2660328_0_cpython
-  - pandas
-  - biopython
+  - pandas=2.1.1=py39hddac248_1
+  - biopython=1.81=py39h72bdee0_0
   - readline=8.1.2=h0f457ee_0
   - setuptools=65.5.0=pyhd8ed1ab_0
   - singularity=3.8.7=h8e8409e_0

--- a/envs/env.yml
+++ b/envs/env.yml
@@ -49,6 +49,8 @@ dependencies:
   - openssl=3.0.5=h166bdaf_2
   - pip=22.3=pyhd8ed1ab_0
   - python=3.9.13=h2660328_0_cpython
+  - pandas
+  - biopython
   - readline=8.1.2=h0f457ee_0
   - setuptools=65.5.0=pyhd8ed1ab_0
   - singularity=3.8.7=h8e8409e_0

--- a/vfnext/configs/containers.config
+++ b/vfnext/configs/containers.config
@@ -50,9 +50,6 @@ process {
     withName:fixWGS {
         container = "$projectDir/containers/singularity_pythonScripts.sif"
     }
-    withName:compileOutputs {
-        container = "$projectDir/containers/singularity_pythonScripts.sif"
-    }
     withName:runSnpEff{
         container = "$projectDir/containers/singularity_snpeff.sif"
     }

--- a/vfnext/modules/compileOutput.nf
+++ b/vfnext/modules/compileOutput.nf
@@ -10,7 +10,7 @@ process compileOutputs{
     path("*")
   script:
     """
-    compileOutput.py -dD ${params.outDir} \
+    python $projectDir/bin/compileOutput.py -dD ${params.outDir} \
                             -oD ./ \
                             --depth ${params.depth} \
                             -virus_tag ${virus_tag}


### PR DESCRIPTION
This PR changes the way of compileOutput.py script runs to work on viralflow env due to some inconsistencies when running inside the container on HPC. 