### PR TITLE
fix splitting of R1 and R2 unmapped reads

### DIFF
--- a/vfnext/modules/bamToFastq.nf
+++ b/vfnext/modules/bamToFastq.nf
@@ -7,8 +7,8 @@ process bamToFastq(){
         tuple val(sample_id), path("${sample_id}.unmapped.*.bam.fq")
     script:
     """
-    bedtools bamtofastq -i unmapped.R1.bam -fq ${sample_id}.unmapped.R1.bam.fq
-    bedtools bamtofastq -i unmapped.R2.bam -fq ${sample_id}.unmapped.R2.bam.fq
+    bedtools bamtofastq -i unmapped.bam -fq ${sample_id}.unmapped.R1.bam.fq\
+    -fq2 ${sample_id}.unmapped.R2.bam.fq
     """
 
 }

--- a/vfnext/modules/getUnmappedReads.nf
+++ b/vfnext/modules/getUnmappedReads.nf
@@ -5,12 +5,13 @@ process getUnmappedReads {
         tuple val(sample_id), path(bam_files)
 
     output:
-        tuple val(sample_id), path("unmapped.R*.bam")
+        tuple val(sample_id), path("unmapped.bam")
 
     script:
     """
     samtools view -b -f 4 ${sample_id}.sorted.bam > unmapped.bam
-    samtools view -hbf 64 unmapped.bam > unmapped.R1.bam
-    samtools view -hbf 128 unmapped.bam > unmapped.R2.bam
+    samtools sort -n -o unmapped.bam unmapped.bam
+#    samtools view -hbf 64 unmapped.bam > unmapped.R1.bam
+#    samtools view -hbf 128 unmapped.bam > unmapped.R2.bam
     """
 }

--- a/vfnext/modules/getUnmappedReads.nf
+++ b/vfnext/modules/getUnmappedReads.nf
@@ -11,6 +11,5 @@ process getUnmappedReads {
     """
     samtools view -b -f 4 ${sample_id}.sorted.bam > unmapped.bam
     samtools sort -n -o unmapped.bam unmapped.bam
-#    samtools view -hbf 128 unmapped.bam > unmapped.R2.bam
     """
 }

--- a/vfnext/modules/getUnmappedReads.nf
+++ b/vfnext/modules/getUnmappedReads.nf
@@ -11,7 +11,6 @@ process getUnmappedReads {
     """
     samtools view -b -f 4 ${sample_id}.sorted.bam > unmapped.bam
     samtools sort -n -o unmapped.bam unmapped.bam
-#    samtools view -hbf 64 unmapped.bam > unmapped.R1.bam
 #    samtools view -hbf 128 unmapped.bam > unmapped.R2.bam
     """
 }


### PR DESCRIPTION
This PR fix the correct splitting of R1 and R2 unmapped reads from umapped.bam.